### PR TITLE
Adding service type label

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -59,14 +59,6 @@ install_otelcol_agent
 arrow "Installing startup script ..."
 mkdir -p $BUILD_DIR/.profile.d
 cat > ${BUILD_DIR}/.profile.d/accurate-scaler.sh <<-SH
-function proctype() {
-  for monitored_proctype in \$monitored_proctypes; do
-    if [[ \$DYNO =~ ^\$monitored_proctype.* ]]; then
-      echo \$monitored_proctype
-    fi
-  done
-}
-
 export PATH=\$PATH:\$HOME/bin
 export ACCURATE_SCALER_ADDON=\$(env | grep "^ACCURATE_SCALER.*_APP_ID=" | sed 's/^\\(ACCURATE_SCALER.*\\)_APP_ID.*$/\\1/g' || true)
 
@@ -76,11 +68,14 @@ if [[ ! -x \$HOME/bin/accurate-scaler-otelcol-agent ]]; then
   exit 1
 fi
 
-monitored_proctypes=\${ACCURATE_SCALER_MONITORED_PROCTYPES:-web worker}
-dyno_proctype=\$(proctype)
+for process_type in \${ACCURATE_SCALER_MONITORED_SERVICE_TYPES:-web worker}; do
+  if [[ \$DYNO =~ ^\$process_type.* ]]; then
+    export ACCURATE_SCALER_SERVICE_TYPE=\$process_type
+  fi
+done
 
 # Check if dyno is running a monitored process type or notify and exit without failing
-if [[ \$dyno_proctype == "" ]]; then
+if [[ \$ACCURATE_SCALER_SERVICE_TYPE == "" ]]; then
   echo "[accurate-scaler] WARNING: Dyno '\$DYNO' is not running a monitored process type. OTel Collector Agent won't be started."
 else
   # Check if add-on is (correctly) installed or notify and exit with error.
@@ -124,6 +119,9 @@ processors:
           - action: add_label
             new_label: instance_id
             new_value: "\${DYNO}"
+          - action: add_label
+            new_label: service_type
+            new_value: "\${ACCURATE_SCALER_SERVICE_TYPE}"
           - action: add_label
             new_label: accurate_scaler_app_id
             new_value: "\${\${ACCURATE_SCALER_ADDON}_APP_ID}"


### PR DESCRIPTION
We add a service type label to all metrics sent in order to filter based on service type: _web_, _worker_, etc.